### PR TITLE
Clarify Syntax of the `#VERSION` Header

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -231,19 +231,19 @@ Implementations SHOULD refuse to load absolutely referenced files.
 ```
 Required:     Yes
 Multi-Valued: No
-Syntax:       <valid semver>
+Syntax:       1*DIGIT period 1*DIGIT period 1*DIGIT
 Since:        1.0.0
 ```
 
 The `VERSION` header indicates the version of this specification that a file complies to.
-The value of the tag is a [semantic version](https://semver.org),
-meaning that an implementation supporting version 1.0.0 of this spec should be able to process files using a version of 1.1.0 without any changes (although new features might not be supported).
+The value of the header is a triplet of numbers separated by periods.
+Similar to [semantic versioning ´](https://semver.org) the version number implicates a certain level of compatibility.
+In particular an implementation supporting version 1.0.0 of this spec should be able to process files using a version of 1.1.0 without any changes (although new features might not be supported).
 Implementations SHOULD NOT attempt to process files with a higher major version than they were designed to work with.
 
 In absence of the `VERSION` header implementations SHOULD assume the version 0.3.0.
 Implementations SHOULD reject a file based on the value of the `VERSION` header,
 in particular if the value is syntactically invalid.
-Applications MAY reject prerelease-versions altogether.
 
 The `VERSION` header SHOULD be the first header in a file.
 


### PR DESCRIPTION
### What does this PR do?

This PR clarifies the supported and intended syntax of the `#VERSION` header.
Following the discussion in #13 this PR clarifies that valid values of the version header look like `1.2.3` and are intended to be have similarly to SermVer. However not all of the SemVer syntax is being used (e.g. prereleases).

### Closes Issue(s)

Relates to #13.

### Motivation

I feel like stating that the `#VERSION` header can be any valid SemVer is misleading if there is no intent of making use of prereleases or metadata. Having the syntax stated more clearly avoids misunderstandings and simplifies implementations.