### PR TITLE
Typo in DuetSingerP1 - P9

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -623,7 +623,7 @@ If a song uses the voice change `Pn` the corresponding `Pn` header is required.
 >
 > The exact semantics of the `P` headers have not been decided yet.
 
-### 3.25. The `DUETSINGER1` thru `DUETSINGER9` Headers
+### 3.25. The `DUETSINGERP1` thru `DUETSINGERP9` Headers
 
 ```
 Required:     No
@@ -633,7 +633,7 @@ Deprecated:   0.3.0
 Removed:      1.0.0
 ```
 
-The headers `DUETSINGER1`, `DUETSINGER2`, …, `DUETSINGER9` are aliases for [`P1`](#324-the-p1-thru-p9-headers) thru [`P9`](#324-the-p1-thru-p9-headers), etc.
+The headers `DUETSINGERP1`, `DUETSINGERP2`, …, `DUETSINGERP9` are aliases for [`P1`](#324-the-p1-thru-p9-headers) thru [`P9`](#324-the-p1-thru-p9-headers), etc.
 If both are specified [`P1`](#324-the-p1-thru-p9-headers) thru [`P9`](#324-the-p1-thru-p9-headers), headers take precedence.
 
 ### 3.26. The `CREATOR` Header


### PR DESCRIPTION


### What does this PR do?

Fixes a typo in the formal spec:
Website states DUETSINGERP1 instead of DUETSINGER1
<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
