### PR TITLE
Remove note about header terminology

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -123,11 +123,6 @@ Each line in the header section starts with a hash.
 The key and value of a header are separated by a colon.
 Whitespace around key and value is ignored.
 
-> [!CAUTION]
->
-> The terminology “header” is not decided yet.
-> Other terms used for the same concept are “tag”, “attribute” or “field”.
-
 ```abnf
 file-header  = *( header-line / empty-line )
 header-line  = hash *WSP header-key *WSP colon *WSP header-value *WSP line-break
@@ -614,7 +609,7 @@ The curated list contains:
 - Underrated
 - Video Game
 - Viral Hit
- 
+
 A list of eligable SingStar editions is available [here](https://github.com/bohning/usdb_syncer/wiki/SingStar-Editions).
 A list of eligable RockBand editions is available [here](https://github.com/bohning/usdb_syncer/wiki/RockBand-Editions).
 A list of eligable Guitar Hero editions is available [here](https://github.com/bohning/usdb_syncer/wiki/GuitarHero-Editions).


### PR DESCRIPTION
### What does this PR do?

This PR codifies the terminology of a "header". Header keys and values define the metadata of an UltraStar file.

### Closes Issue(s)

None

### Motivation

I think this the terminology originally introduced in #48 has now kind of stuck and has been used in other issues as well such as #59 or #67. I think the note about unclear terminology is no longer required.