### PR TITLE
Standardize Application-Specific Headers

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -149,14 +149,13 @@ Implementations MAY remove leading and trailing whitespace in header keys and va
 Header values may not exceed 255 characters.
 
 Implementations MAY define application-specific headers
-but SHOULD prefix those headers with the application name to avoid conflicts with future standardized headers.
+but SHOULD prefix those headers with the application name and a hyphen (`%x2D`) to avoid conflicts with future standardized headers.
+For example an application `Foo Bar` might use the application-specific header `#FOO_BAR-SPEED`.
+Standardized headers are guaranteed to not include a hyphen.
+If an application-specific header at some point becomes standardized, the standardized header takes precedence.
 Implementations MUST ignore headers they do not recognize.
 The order of headers is irrelevant (note the exception in section 3.1.)
 although standardized headers should precede any application-specific headers.
-
->  [!CAUTION]
->
-> Handling of application-specific headers has not been decided yet.
 
 The following sections describe the standardized headers that have been defined.
 If a syntax for a header is specified it applies to the `single-value`.


### PR DESCRIPTION
### What does this PR do?

This PR standardizes the notion of application-specific headers. An application-specific header is a header that is not covered by this specification but used by an implementation. This PR standardizes the format for application-specific headers.

Example:
If an application `Foo Bar` wants to introduce a header for the speed of a song (whatever that may mean) it could use the application-specific header `#FOO_BAR-SPEED`.

### Closes Issue(s)

Closes #56 

### Motivation

See #56 

### Additional Notes

I have used the hyphen as a separator for application-specific headers because I found it to be visually more convincing. There is a small technical benefit in that double-clicking a word usually includes underscores but not hyphens. So using an underscore as a separator (and potentially a hyphen within the application or header name) would be a little more difficult to double-click-copy. I am open to change this if another pattern is preferred.
