### PR TITLE
Remove size limit on header values

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -146,7 +146,8 @@ For the sake of consistency header keys SHOULD use only capital letters.
 Header values are generally case-sensitive unless otherwise specified.
 An empty value is equivalent to the header being absent.
 Implementations MAY remove leading and trailing whitespace in header keys and values without changing semantics.
-Header values may not exceed 255 characters.
+This specification imposes no limit on the size of a single header value.
+Note that implementations may have technical limitations so it is recommended that neither a header key nor a header value exceeds 2048 bytes.
 
 Implementations MAY define application-specific headers
 but SHOULD prefix those headers with the application name and a hyphen (`%x2D`) to avoid conflicts with future standardized headers.


### PR DESCRIPTION
### What does this PR do?

This PR removes the size limitation for header values. The previous 255 character limit was in place because of historical reasons that do not apply anymore.

### Closes Issue(s)

Closes #78

### Motivation

See https://github.com/UltraStar-Deluxe/format/issues/78#issue-2861043315

### Additional Notes

This PR includes a recommendation that header keys and values do not exceed 2048 bytes. The idea is that implementations can use this as a guideline in preventing buffer overflows. The specific number is pretty arbitrary, but it is large enough to hold [all practical URLs](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers).
