### PR TITLE
Fix section linking

### DIFF
--- a/The UltraStar File Format (Unversioned).md
+++ b/The UltraStar File Format (Unversioned).md
@@ -164,7 +164,7 @@ The value of this tag is arbitrary in the sense that it is usually 1 to 2 times 
 Required: Yes
 ```
 
-The `MP3` header contains a file reference (as defined in [Section 3.1.](#31-file-references)) to an audio file.
+The `MP3` header contains a file reference (as defined in [Section 3.1](#31-file-references)) to an audio file.
 Supported audio formats are an implementation detail.
 
 ### 3.5. The `#TITLE` Header
@@ -299,7 +299,7 @@ Required: No
 ```
 
 The headers `#P1` and `#P2` indicate the names of the voices of a song.
-These names correspond to the voices indicated by the `#P1` and `#P2` voice changes (see [Section 3.3](#33-voice-changes)).
+These names correspond to the voices indicated by the `#P1` and `#P2` voice changes (see [Section 4.3](#43-voice-changes)).
 If the voices correspond to different singers in the original song, the header values often indicate the names of the original singers.
 
 > [!NOTE]
@@ -498,7 +498,7 @@ Each voice change SHOULD only appear once in ascending order of `voice-number`.
 ### A. Relative Mode
 
 Relative mode is a special input mode that affects parsing and interpreting songs significantly.
-Relative mode is enabled by the [`#RELATIVE`](#330-the-relative-header) header being set to `yes` (case-insensitive).
+Relative mode is enabled by the [`#RELATIVE`](#322-the-relative-header) header being set to `yes` (case-insensitive).
 
 #### Syntax
 
@@ -534,3 +534,4 @@ The `rel` value for a voice does not reset when a voice change is encountered.
 ## Revision History
 
 - 2025-03-07: First revision
+- 2025-04-22: Fixed section linking

--- a/The UltraStar File Format (v1).md
+++ b/The UltraStar File Format (v1).md
@@ -204,7 +204,7 @@ The value of this tag is arbitrary in the sense that it is usually 1 to 2 times 
 Required: Yes
 ```
 
-The `MP3` header contains a file reference (as defined in [Section 3.2.](#32-file-references)) to an audio file.
+The `MP3` header contains a file reference (as defined in [Section 3.2](#32-file-references)) to an audio file.
 This file contains the full version of a song (including instrumentals and vocals).
 Supported audio formats are an implementation detail.
 
@@ -257,7 +257,7 @@ Required: Yes for multi-voice songs, No for single-voice songs
 ```
 
 The headers `#P1`, `#P2`, …, `#P9` indicate the names of the voices of a song.
-These names correspond to the voices indicated by the `#P1`, `#P2`, …, `#P9` voice changes (see [section 3.3](#43-voice-changes)).
+These names correspond to the voices indicated by the `#P1`, `#P2`, …, `#P9` voice changes (see [Section 4.3](#43-voice-changes)).
 If the voices correspond to different singers in the original song, the header values often indicate the names of the original singers.
 
 The association of header values to voices is defined by the numerical value after each `P` respectively,
@@ -602,3 +602,4 @@ Examples:
 - 2025-03-07: Major revision wrt wording and structure
 - 2025-04-20: The `RENDITION` header
 - 2025-04-22: Clarification of the meaning of spaces before/after syllables
+- 2025-04-22: Fixed section linking

--- a/The UltraStar File Format (v2).md
+++ b/The UltraStar File Format (v2).md
@@ -258,7 +258,7 @@ Required: Yes for multi-voice songs, No for single-voice songs
 ```
 
 The headers `#P1`, `#P2`, …, `#P9` indicate the names of the voices of a song.
-These names correspond to the voices indicated by the `P1`, `P2`, …, `P9` voice changes (see [section 3.3](#33-voice-changes)).
+These names correspond to the voices indicated by the `P1`, `P2`, …, `P9` voice changes (see [Section 4.3](#43-voice-changes)).
 If the voices correspond to different singers in the original song, the header values often indicate the names of the original singers.
 
 The association of header values to voices is defined by the numerical value after each `P` respectively,
@@ -409,7 +409,7 @@ To improve readability notes for different voices should not be interlaced.
 > A voice change does NOT implicitly add an end-of-phrase indicator.
 
 Voice changes SHOULD appear in ascending order of `voice-number` and there SHOULD be no gaps (i.e. a song having notes for `P1` and `P3`, but not `P2`).
-The exact `voice-number` carries no semantics other than its relative order with other `voice-number` and its association with the corresponding header (see (see [Section 3.3.8](#338-the-p1-thru-p9-headers)).
+The exact `voice-number` carries no semantics other than its relative order with other `voice-number` and its association with the corresponding header (see [Section 3.3.8](#338-the-p1-thru-p9-headers)).
 In particular a file that uses `P3` and `P5` can be rewritten using `P1` and `P2` with no change in semantics.
 
 > [!TIP]


### PR DESCRIPTION
Format fixes:
- Fixes references and links to Section `4.2. Voice Changes` as `3.2. Voice Changes` in all spec versions.
- Fixes link to Section `3.22. The #RELATIVE Header` as `3.30` in unversioned spec.
- Fixes repeated "(see " in spec v2.