### PR TITLE
Fix units for #END header

### DIFF
--- a/The UltraStar File Format (Unversioned).md
+++ b/The UltraStar File Format (Unversioned).md
@@ -220,8 +220,15 @@ Required: No
 Syntax:   1*DIGIT [ (period / comma) 1*DIGIT ]
 ```
 
-The `#START` and `#END` header specify two time points in seconds relative to the start of the audio data that indicate a start and end point for the song.
+The `#START` and `#END` header specify two time points relative to the start of the audio data that indicate a start and end point for the song.
+`#START` is specified as a decimal value in seconds.
+`#END` is specified as a decimal value in milliseconds.
 Game implementations SHOULD start and end the song at the specified points and scale scoring accordingly.
+
+> [!NOTE]
+>
+> There are known implementations that only support integer values for `#END`.
+> In the interest of compatibility it is recommended to restrict values to integers.
 
 > [!NOTE]
 >
@@ -535,3 +542,4 @@ The `rel` value for a voice does not reset when a voice change is encountered.
 
 - 2025-03-07: First revision
 - 2025-04-22: Fixed section linking
+- 2025-05-23: Fix time unit for `#END` header

--- a/The UltraStar File Format (v1).md
+++ b/The UltraStar File Format (v1).md
@@ -242,8 +242,15 @@ Required: No
 Syntax:   1*DIGIT [ (period / comma) 1*DIGIT ]
 ```
 
-The `#START` and `#END` header specify two time points in seconds relative to the start of the audio data that indicate a start and end point for the song.
+The `#START` and `#END` header specify two time points relative to the start of the audio data that indicate a start and end point for the song.
+`#START` is specified as a decimal value in seconds.
+`#END` is specified as a decimal value in milliseconds.
 Game implementations SHOULD start and end the song at the specified points and scale scoring accordingly.
+
+> [!NOTE]
+>
+> There are known implementations that only support integer values for `#END`.
+> In the interest of compatibility it is recommended to restrict values to integers.
 
 > [!NOTE]
 >
@@ -606,3 +613,4 @@ Examples:
 - 2025-04-22: Clarification of the meaning of spaces before/after syllables
 - 2025-04-22: Fixed section linking
 - 2025-05-20: Clarify handling of unknown note types
+- 2025-05-23: Fix time unit for `#END` header


### PR DESCRIPTION
### What does this PR do?

This PR fixes the units used for the `#END` header in the unversioned and v1 format.

### Closes Issue(s)

Fixes #90 

### Motivation

The spec incorrectly describes the `#END` header as using seconds as a unit. It is actually in milliseconds. See #90.

### Additional Notes

This PR targets both v1 and the unversioned format. I think it is worth to apply this change to the unversioned format as well, even though it is archived. I wouldn't want to have wrong information in the current revision of any of the versions.
