### PR TITLE
Issue Rejection Workflow

### DIFF
--- a/.github/workflows/manage-issue.yaml
+++ b/.github/workflows/manage-issue.yaml
@@ -1,0 +1,31 @@
+name: Manage Issues
+
+on:
+  issues:
+    types: [closed, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-reject:
+    name: Manage 'Rejected' Label
+    if: github.event.action == 'closed' || github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Rejected Label
+        if: github.event.issue.state_reason == 'not_planned'
+        run: gh issue edit "$ISSUE" --add-label "$LABEL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          LABEL: Rejected
+      - name: Remove Rejected Label
+        if: github.event.issue.state_reason != 'not_planned'
+        run: gh issue edit "$ISSUE" --remove-label "$LABEL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          LABEL: Rejected


### PR DESCRIPTION
### What does this PR do?

This PR adds a GitHub workflow that automatically manages the "Rejected" label on issues. When an issue is closed as "not planned", the label is added. When it is reopened, the label is removed.

### Closes Issue(s)

None

### Motivation

Managing labels on issues can be error-prone and is often a manual step. This is a step to automate label management where possible.

### Additional Notes

The "Rejected" label basically just duplicates the same information that is provided by the "not planend" status. It might also make sense to remove the label entirely. Issues can be filtered via `is:issue is:closed reason:not-planned` anyway (which would be my preferred approach).